### PR TITLE
Store hide ai users option in local storage

### DIFF
--- a/games-vue-client/src/components/StartScreen.vue
+++ b/games-vue-client/src/components/StartScreen.vue
@@ -1,19 +1,6 @@
 <template>
   <v-container fluid>
-    <v-row>
-      <v-col cols="1">
-        <v-checkbox
-          v-model="hideAIUsers"
-          label="Hide AI Users"
-          @change="toggleAIUsers()"
-        />
-      </v-col>
-      <v-col
-        cols="11"
-        sm="6"
-        md="2"
-      />
-    </v-row>
+    <LobbyOptions />
     <v-row>
       <v-col
         v-for="(users, gameType) in lobby"
@@ -78,7 +65,7 @@
 <script>
 import Socket from "@/socket";
 import LobbyGameType from "@/components/lobby/LobbyGameType";
-
+import LobbyOptions from "@/components/lobby/LobbyOptions"
 import { mapState } from "vuex";
 import supportedGames from "@/supportedGames";
 
@@ -88,11 +75,11 @@ export default {
     return {
       gameList: [],
       unfinishedGames: [],
-      hideAIUsers: false
     };
   },
   components: {
     LobbyGameType,
+    LobbyOptions,
     ...supportedGames.components()
   },
   mounted() {
@@ -123,9 +110,6 @@ export default {
     },
     resumeGame(gameType, gameId) {
       this.$router.push(`/games/${gameType}/${gameId}`)
-    },
-    toggleAIUsers() {
-      this.$store.commit("lobby/toggleAIUsers", this.hideAIUsers);
     },
   },
   created() {

--- a/games-vue-client/src/components/invites/InviteScreen.vue
+++ b/games-vue-client/src/components/invites/InviteScreen.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container fluid>
+    <LobbyOptions />
     <h3 v-if="invite">
       {{ invite.host.name }} is preparing a game of {{ invite.gameType }}
     </h3>
@@ -87,12 +88,13 @@
 <script>
 import { mapState } from "vuex"
 import InvitePlayer from "@/components/lobby/InvitePlayer"
+import LobbyOptions from "@/components/lobby/LobbyOptions"
 import Socket from "@/socket"
 
 export default {
     name: "InviteScreen",
     props: ["inviteId"],
-    components: { InvitePlayer },
+    components: { InvitePlayer, LobbyOptions },
     mounted() {
         console.log("InviteScreen mounted")
         if (this.users.length === 0 && Socket.isConnected()) {
@@ -116,7 +118,8 @@ export default {
         },
         startInvite() {
             Socket.route(`invites/${this.inviteId}/start`);
-        }
+        },
+
     },
     computed: {
         gameStartable() {
@@ -140,7 +143,7 @@ export default {
             },
             users(state) {
                 if (!this.invite) return [];
-                return state.lobby[this.invite.gameType] || []
+                return state.lobby[this.invite.gameType].filter((player) => !player.hidden) || []
             }
         }),
         isInGame() {

--- a/games-vue-client/src/components/lobby/LobbyOptions.vue
+++ b/games-vue-client/src/components/lobby/LobbyOptions.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-row>
+    <v-col cols="1">
+      <v-checkbox
+        v-model="hideAIUsers"
+        label="Hide AI Users"
+        @change="toggleAIUsers()"
+      />
+    </v-col>
+    <v-col
+      cols="11"
+      sm="6"
+      md="2"
+    />
+  </v-row>
+</template>
+<script>
+export default {
+    name: "LobbyOptions",
+    data() {
+      return {
+        hideAIUsers: false
+      }
+    },
+    mounted() {
+      if (localStorage.hideAIUsers && localStorage.hideAIUsers === 'true' != this.hideAIUsers) {
+        this.hideAIUsers = localStorage.hideAIUsers === 'true';
+      }
+    },
+    methods: {
+      toggleAIUsers() {
+        this.$store.commit("lobby/setLobbyUsersWithOptions", { hideAIUsers: !!this.hideAIUsers });
+      },
+    },    
+    watch: {
+      hideAIUsers(newHideAIUsers) {
+        localStorage.hideAIUsers = newHideAIUsers;
+      }
+    }
+}
+</script>

--- a/games-vue-client/src/components/lobby/lobbyStore.js
+++ b/games-vue-client/src/components/lobby/lobbyStore.js
@@ -60,11 +60,12 @@ const lobbyStore = {
         throw "Unknown action: " + e.action;
       }
     },
-    toggleAIUsers(state, hidden) {
-      state.lobby = Object.entries(state.lobby).reduce((acc, [gameType, players]) => {
+    setLobbyUsersWithOptions(state, { data, hideAIUsers }) {
+      const newData = data || state.lobby;
+      state.lobby = Object.entries(newData).reduce((acc, [gameType, players]) => {
         const updatedPlayers = Object.values(players).map((player) => {
           if (player.name.includes('#AI_')) {
-            return { ...player, hidden: !!hidden };
+            return { ...player, hidden: hideAIUsers };
           }
           return player;
         });
@@ -92,7 +93,12 @@ const lobbyStore = {
     },
     onSocketMessage(context, data) {
       if (data.type == "Lobby") {
-        context.commit("setLobbyUsers", data.users);
+        const { hideAIUsers } = localStorage;
+        if (hideAIUsers) {
+          context.commit("setLobbyUsersWithOptions", { data: data.users, hideAIUsers: hideAIUsers === 'true' });
+        } else {
+          context.commit("setLobbyUsers", data.users);
+        }
       }
       if (data.type === "LobbyChange") {
         context.commit("changeLobby", data);


### PR DESCRIPTION
## Included

* Store hide AI users option in local storage.
* Store lobby option in own component.
* Also add lobby option to invite screen.

## Results

Now you see me:
![image](https://user-images.githubusercontent.com/724709/99883206-2836ee00-2c26-11eb-983f-faa50222dc64.png)

Now you don't:
![image](https://user-images.githubusercontent.com/724709/99883196-1e14ef80-2c26-11eb-9f3e-f9979e9d3f2e.png)

## Client Side Storage

https://vuejs.org/v2/cookbook/client-side-storage.html#Alternative-Patterns