### PR TITLE
Display dark mode settings. Connect setting with vuetify.

### DIFF
--- a/games-vue-client/src/components/SettingsView.vue
+++ b/games-vue-client/src/components/SettingsView.vue
@@ -1,19 +1,33 @@
 <template>
-  <v-menu transition="slide-y-transition" offset-y>
+  <v-menu
+    transition="slide-y-transition"
+    offset-y
+  >
     <template v-slot:activator="{ on }">
-      <v-btn v-on="on" text>
-        <v-icon color="black">mdi-cog</v-icon>
+      <v-btn
+        text
+        v-on="on"
+      >
+        <v-icon color="black">
+          mdi-cog
+        </v-icon>
       </v-btn>
     </template>
     <v-list>
       <v-slider
         v-show="false"
-        class="slider"
         v-model="volume"
+        class="slider"
         prepend-icon="mdi-volume-high"
         @click:prepend="mute"
       />
-      <v-checkbox v-show="false" v-model="theme" value="dark" label="Dark mode" />
+      <v-checkbox
+        v-show="true"
+        v-model="theme"
+        value="dark"
+        label="Dark mode"
+        prepend-icon="mdi-theme-light-dark"
+      />
       <v-checkbox
         v-model="hideAIUsers"
         label="Hide AI Users"
@@ -31,7 +45,7 @@ export default {
   data() {
     let volume = parseInt(localStorage.volume || "42", 10);
     return {
-      previousVolume: volume
+      previousVolume: volume,
     };
   },
   computed: {
@@ -40,17 +54,25 @@ export default {
         return this.$store.state.settings.hideAIUsers;
       },
       set(value) {
-        this.$store.commit("settings/set", { key: "hideAIUsers", value: value ? "true" : "" });
-        this.$store.commit("lobby/setLobbyUsersWithOptions", { hideAIUsers: !!this.hideAIUsers });
-      }
+        this.$store.commit("settings/set", {
+          key: "hideAIUsers",
+          value: value ? "true" : "",
+        });
+        this.$store.commit("lobby/setLobbyUsersWithOptions", {
+          hideAIUsers: !!this.hideAIUsers,
+        });
+      },
     },
     playSoundOnPlayerTurn: {
       get() {
         return this.$store.state.settings.playSoundOnPlayerTurn;
       },
       set(value) {
-        this.$store.commit("settings/set", { key: "playSoundOnPlayerTurn", value: value ? "true" : "" });
-      }
+        this.$store.commit("settings/set", {
+          key: "playSoundOnPlayerTurn",
+          value: value ? "true" : "",
+        });
+      },
     },
     volume: {
       get() {
@@ -58,7 +80,7 @@ export default {
       },
       set(value) {
         this.$store.commit("settings/setVolume", value);
-      }
+      },
     },
     theme: {
       get() {
@@ -66,16 +88,17 @@ export default {
       },
       set(value) {
         this.$store.commit("settings/setTheme", value);
-      }
-    }
+        this.$vuetify.theme.dark = !this.$vuetify.theme.dark;
+      },
+    },
   },
   methods: {
     mute() {
       let previousVolume = this.volume;
       this.volume = this.volume === 0 ? this.previousVolume : 0;
       this.previousVolume = previousVolume;
-    }
-  }
+    },
+  },
 };
 </script>
 <style scoped>

--- a/games-vue-client/src/components/invites/InviteScreen.vue
+++ b/games-vue-client/src/components/invites/InviteScreen.vue
@@ -17,7 +17,7 @@
       <v-card-text>
         <v-row>
           <v-col cols="12">
-            <v-list light>
+            <v-list>
               <template v-for="(player, index) in users">
                 <v-divider
                   v-if="index > 0"

--- a/games-vue-client/src/components/lobby/LobbyGameType.vue
+++ b/games-vue-client/src/components/lobby/LobbyGameType.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-card class="game-type" :class="gameTypeCssName">
+  <v-card
+    class="game-type"
+    :class="gameTypeCssName"
+  >
     <v-toolbar
       color="cyan"
       dark
@@ -22,7 +25,7 @@
     <v-card-title>
       Users
     </v-card-title>
-    <v-list light>
+    <v-list>
       <template v-for="(player, index) in users">
         <v-divider
           v-if="index > 0"

--- a/games-vue-client/src/main.js
+++ b/games-vue-client/src/main.js
@@ -17,5 +17,9 @@ new Vue({
   router,
   components: { App },
   vuetify,
-  template: "<App/>"
+  template: "<App/>",
+  mounted() {
+      const { theme } = localStorage;
+      this.$vuetify.theme.dark = theme === "dark";
+  },
 });


### PR DESCRIPTION
Using inspiration from https://dev.to/hkamran/using-local-storage-to-store-vuetify-s-dark-theme-state-4e6g

![image](https://user-images.githubusercontent.com/724709/113471973-488e7900-9460-11eb-8598-65f211573500.png)

![image](https://user-images.githubusercontent.com/724709/113471990-61972a00-9460-11eb-9e29-da6a210c3192.png)

![image](https://user-images.githubusercontent.com/724709/113471901-d6b62f80-945f-11eb-97d9-0c35d650571e.png)

![image](https://user-images.githubusercontent.com/724709/113471958-36143f80-9460-11eb-826e-42ed1cfe5e21.png)

![image](https://user-images.githubusercontent.com/724709/113471986-5ba14900-9460-11eb-815a-6f42903eb9e8.png)

![image](https://user-images.githubusercontent.com/724709/113471917-ecc3f000-945f-11eb-802c-e208efc1abe1.png)